### PR TITLE
Refactor/nfc select card api

### DIFF
--- a/Peripherals/nfc/adafruit_pn532.c
+++ b/Peripherals/nfc/adafruit_pn532.c
@@ -36,6 +36,7 @@
 #ifndef TAG_DETECT_TIMEOUT
 #define TAG_DETECT_TIMEOUT  4000
 #define SHORT_TIMEOUT       500
+#define VERY_SHORT_TIMEOUT  10
 #endif
 
 #ifndef PN532_IRQ
@@ -1199,10 +1200,9 @@ ret_code_t adafruit_diagnose_card_presence()
         return err_code;
     }
 
-    // Note : The wait time was increased from 1 sec to 10 sec as some APDU in card upgrade take longer than 1 sec
-    if (!adafruit_pn532_waitready_ms(SHORT_TIMEOUT))
+    if (!adafruit_pn532_waitready_ms(VERY_SHORT_TIMEOUT))
     {
-        return STM_ERROR_INTERNAL;
+        return STM_ERROR_TIMEOUT;
     }
 
     err_code = adafruit_pn532_data_read(m_pn532_packet_buf,

--- a/Peripherals/nfc/adafruit_pn532.c
+++ b/Peripherals/nfc/adafruit_pn532.c
@@ -505,7 +505,7 @@ ret_code_t adafruit_pn532_passive_activation_retries_set(uint8_t max_retries)
     return STM_SUCCESS;
 }
 
-ret_code_t pn532_set_nfca_target_init_command(){
+ret_code_t pn532_set_nfca_target_init_command(void){
     m_pn532_packet_buf[0] = PN532_COMMAND_INLISTPASSIVETARGET;
     m_pn532_packet_buf[1] = 1; // Maximum number of targets.
     m_pn532_packet_buf[2] = PN532_MIFARE_ISO14443A_BAUD;
@@ -1184,7 +1184,7 @@ ret_code_t adafruit_diagnose_comm_line(uint8_t * p_send, uint8_t send_len)
     return STM_SUCCESS;
 }
 
-ret_code_t adafruit_diagnose_card_presence()
+ret_code_t adafruit_diagnose_card_presence(void)
 {
     uint8_t p_response_len = 1;
 
@@ -1232,6 +1232,7 @@ ret_code_t adafruit_diagnose_card_presence()
         return m_pn532_packet_buf[PN532_DATA_OFFSET + 1];
     }
 
+    // Return the status byte received from PN532 response.
     return m_pn532_packet_buf[PN532_DATA_OFFSET + 1];
 }
 

--- a/Peripherals/nfc/adafruit_pn532.c
+++ b/Peripherals/nfc/adafruit_pn532.c
@@ -504,6 +504,60 @@ ret_code_t adafruit_pn532_passive_activation_retries_set(uint8_t max_retries)
     return STM_SUCCESS;
 }
 
+ret_code_t pn532_set_nfca_target_init_command(){
+    m_pn532_packet_buf[0] = PN532_COMMAND_INLISTPASSIVETARGET;
+    m_pn532_packet_buf[1] = 1; // Maximum number of targets.
+    m_pn532_packet_buf[2] = PN532_MIFARE_ISO14443A_BAUD;
+
+    ret_code_t err_code = adafruit_pn532_cmd_send(m_pn532_packet_buf,
+                                                  COMMAND_INLISTPASSIVETARGET_BASE_LENGTH,
+                                                  PN532_DEFAULT_WAIT_FOR_READY_TIMEOUT);
+
+    return err_code;
+}
+
+ret_code_t pn532_read_nfca_target_init_resp(nfc_a_tag_info * p_tag_info){
+    if (p_tag_info == NULL)
+    {
+        return NFC_INVALID_PARAM;
+    }
+    if (!adafruit_pn532_is_ready())
+    {
+        return NFC_RESP_NOT_READY;
+    }
+
+    ret_code_t err_code = adafruit_pn532_data_read(m_pn532_packet_buf,
+                                        REPLY_INLISTPASSIVETARGET_106A_TARGET_LENGTH);
+    if (err_code != STM_SUCCESS)
+    {
+        return err_code;
+    }
+
+    if (m_pn532_packet_buf[REPLY_INLISTPASSIVETARGET_106A_NBTG_OFFSET] != 1)
+    {
+        return NFC_INVALID_RESPONSE;
+    }
+
+    if (MAX_NFC_A_ID_LEN < m_pn532_packet_buf[REPLY_INLISTPASSIVETARGET_106A_UID_LEN_OFFSET])
+    {
+        return NFC_INVALID_LENGTH;
+    }
+
+    p_tag_info->sens_res[SENS_RES_ANTICOLLISION_INFO_BYTE] =
+        m_pn532_packet_buf[REPLY_INLISTPASSIVETARGET_106A_SENS_RES_BYTE_1_OFFSET];
+    p_tag_info->sens_res[SENS_RES_PLATFORM_INFO_BYTE] =
+        m_pn532_packet_buf[REPLY_INLISTPASSIVETARGET_106A_SENS_RES_BYTE_2_OFFSET];
+
+    p_tag_info->sel_res    = m_pn532_packet_buf[REPLY_INLISTPASSIVETARGET_106A_SEL_RES_OFFSET];
+    p_tag_info->nfc_id_len = m_pn532_packet_buf[REPLY_INLISTPASSIVETARGET_106A_UID_LEN_OFFSET];
+    memcpy(p_tag_info->nfc_id,
+           m_pn532_packet_buf + REPLY_INLISTPASSIVETARGET_106A_UID_OFFSET,
+           p_tag_info->nfc_id_len);
+
+    m_pn532_object.in_listed_tag = m_pn532_packet_buf[REPLY_INLISTPASSIVETARGET_106A_TG_OFFSET];
+
+    return STM_SUCCESS;
+}
 
 ret_code_t adafruit_pn532_nfc_a_target_init(nfc_a_tag_info * p_tag_info,
                                             uint16_t         timeout)

--- a/Peripherals/nfc/adafruit_pn532.h
+++ b/Peripherals/nfc/adafruit_pn532.h
@@ -300,10 +300,41 @@ ret_code_t adafruit_pn532_field_on(void);
 ret_code_t adafruit_pn532_field_off(void);
 /** @} */
 
-/**
- * @name Functions for ISO14443A tags
+/**  @brief Function sends command to PN532 for detecting an ISO14443A (NFC-A) target presence in the RF field.
  *
- * @{ */
+ *   @details This function enables the RF field and scans for ISO14443A (NFC-A) targets present
+ *   in the field. The number of scan retries is set by the @ref adafruit_pn532_passive_activation_retries_set
+ *   function. By default, the maximum number of retries is set to unlimited, which means
+ *   that the PN532 Shield scans for targets until it finds one or the scan is
+ *   canceled. When the ISO14443A (NFC-A) target is detected, the PN532 module initializes
+ *   communication and reads the basic initialization information about NFC-A tag including
+ *   SENS_RES, SEL_RES and UID. This information is retrieved by NFC reader during Technology
+ *   Detection and Collision Resolution Activities.
+ *   Once a card has been selected, the PN532 IRQ pin is reset indicating a response is ready
+ *   to be received by the HOST, @ref pn532_read_nfca_target_init_resp should be called to retrieve
+ *   the response from PN532. 
+ *
+ *   @retval        STM_SUCCESS           If the command was sent successfully. Otherwise,
+ *                                        an error code is returned.
+ */
+ret_code_t pn532_set_nfca_target_init_command();
+
+/**  @brief Function reads response from PN532 after detecting an ISO14443A (NFC-A) target presence in the RF field.
+ *
+ *   @details This function should be called after @pn532_set_nfca_target_init_command function to set the command for detecting a ISO14443A (NFC-A) targets presence
+ *   in the field. When the ISO14443A (NFC-A) target is detected, the
+ *   PN532 module initializes communication and reads the basic initialization information 
+ *   about NFC-A tag including SENS_RES, SEL_RES and UID. This information is retrieved by
+ *   NFC reader during Technology Detection and Collision Resolution Activities. Response is only received when the PN532 IRQ has been reset indicating a response is ready with PN532
+ *
+ *   @param[in,out] p_tag_info            Pointer to the structure where NFC-A Tag
+ *                                        basic initialization information will be stored.
+ *
+ *   @retval        STM_SUCCESS           If the function completed successfully. 
+ *                  NFC_RESP_NOT_READY    If PN532 is not in reset state indicating card is not detected.
+ *                                        Otherwise, an error code is returned.
+ */
+ret_code_t pn532_read_nfca_target_init_resp(nfc_a_tag_info * p_tag_info);
 
 /**  @brief Function for detecting an ISO14443A (NFC-A) target presence in the RF field.
  *

--- a/Peripherals/nfc/adafruit_pn532.h
+++ b/Peripherals/nfc/adafruit_pn532.h
@@ -319,7 +319,7 @@ ret_code_t adafruit_pn532_field_off(void);
  *   @retval        STM_SUCCESS           If the command was sent successfully. Otherwise,
  *                                        an error code is returned.
  */
-ret_code_t pn532_set_nfca_target_init_command();
+ret_code_t pn532_set_nfca_target_init_command(void);
 
 /**  @brief Function reads response from PN532 after detecting an ISO14443A (NFC-A) target presence in the RF field.
  *

--- a/Peripherals/nfc/adafruit_pn532.h
+++ b/Peripherals/nfc/adafruit_pn532.h
@@ -166,6 +166,8 @@
 #define MIFARE_CMD_INCREMENT        (0xC1)
 #define MIFARE_CMD_STORE            (0xC2)
 #define MIFARE_ULTRALIGHT_CMD_WRITE (0xA2)
+
+#define PN532_DIAGNOSE_CARD_DETECTED_RESP 0     // Response for PN532 diagnose card presence command
 /** @} */
 
 /**


### PR DESCRIPTION
The current APIs implemented for smart card selection (in adafruit_pn532_nfc_a_target_init) is blocking. Refactored NFC A target init with 2 APIs for setting the command and reading the response when ready. This will mean that instead of being blocked for the response (for about a few seconds by current implementation), the response is being polled.